### PR TITLE
Build our own image running under root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM grafana/grafana:8.2.2
+
+USER root 
+
+ENTRYPOINT ["/run.sh"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,8 +1,5 @@
 app = "grafana-example"
 
-[build]
-image = "grafana/grafana:8.0.0"
-
 [mount]
 source = "grafana_storage"
 destination = "/var/lib/grafana"


### PR DESCRIPTION
As discussed in the forum [here](https://community.fly.io/t/grafana-cannot-write-to-mounted-volume/2877), this repository won't run because Grafana doesn't have write access to our fly volume.
This PR changes it to build our own image with Grafana running under root.
It also bumps the Grafana version.